### PR TITLE
Fix formatting corruption around Unicode color codes

### DIFF
--- a/server/src/Providers/Formatters/ClangFormatter.ts
+++ b/server/src/Providers/Formatters/ClangFormatter.ts
@@ -16,7 +16,7 @@ export default class ClangFormatter extends Formatter {
         return;
       }
 
-      this.currentEdit.text = text;
+      this.currentEdit.text += text;
     };
   }
 
@@ -44,14 +44,15 @@ export default class ClangFormatter extends Formatter {
     };
   }
 
-  private xmlParserOnCloseTag(document: TextDocument) {
+  private xmlParserOnCloseTag(document: TextDocument, utf8Source: Buffer) {
     return () => {
       if (!this.currentEdit) {
         return;
       }
 
-      const start = document.positionAt(this.currentEdit.offset);
-      const end = document.positionAt(this.currentEdit.offset + this.currentEdit.length);
+      // clang-format reports UTF-8 bytes; TextDocument positions use UTF-16.
+      const start = document.positionAt(utf8Source.subarray(0, this.currentEdit.offset).toString("utf8").length);
+      const end = document.positionAt(utf8Source.subarray(0, this.currentEdit.offset + this.currentEdit.length).toString("utf8").length);
 
       this.edits.push({ range: { start, end }, newText: this.currentEdit.text });
       this.currentEdit = null;
@@ -68,11 +69,13 @@ export default class ClangFormatter extends Formatter {
         this.logger.info(`Formatting ${document.uri}:`);
       }
 
+      const text = document.getText();
+      const utf8Source = Buffer.from(text, "utf8");
       const args = ["-output-replacements-xml", `-style=${JSON.stringify(this.style)}`];
 
       if (range) {
-        const offset = document.offsetAt(range.start);
-        const length = document.offsetAt(range.end) - offset;
+        const offset = Buffer.byteLength(text.slice(0, document.offsetAt(range.start)), "utf8");
+        const length = Buffer.byteLength(document.getText(range), "utf8");
 
         args.push(`-offset=${offset}`, `-length=${length}`);
       }
@@ -88,7 +91,9 @@ export default class ClangFormatter extends Formatter {
         cwd: this.workspaceFilesSystem.getWorkspaceRootPath(),
       });
 
-      child.stdin.end(document.getText());
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdin.end(utf8Source);
       child.stdout.on("data", (chunk: string) => (stdout += chunk));
       child.stderr.on("data", (chunk: string) => (stderr += chunk));
 
@@ -101,6 +106,7 @@ export default class ClangFormatter extends Formatter {
         if (code !== 0 || stderr.length !== 0) {
           this.logger.error(stderr);
           reject(new Error(stderr));
+          return;
         }
 
         const xmlParser = parser(true, {
@@ -111,7 +117,7 @@ export default class ClangFormatter extends Formatter {
         xmlParser.onerror = (err) => reject(err);
         xmlParser.ontext = this.xmlParseOnText();
         xmlParser.onopentag = this.xmlParserOnOpenTag(reject);
-        xmlParser.onclosetag = this.xmlParserOnCloseTag(document);
+        xmlParser.onclosetag = this.xmlParserOnCloseTag(document, utf8Source);
         xmlParser.write(stdout);
         xmlParser.end();
 

--- a/server/test/formatter_test.ts
+++ b/server/test/formatter_test.ts
@@ -2,11 +2,14 @@ import { describe, it, afterEach } from "mocha";
 import { expect } from "chai";
 import { EventEmitter } from "events";
 import { PassThrough } from "stream";
+import { resolve } from "path";
+import { pathToFileURL } from "url";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import ClangFormatter from "../src/Providers/Formatters/ClangFormatter";
 
 const childProcess = require("child_process");
 const originalSpawn = childProcess.spawn;
+const testUri = pathToFileURL(resolve("test.nss")).href;
 
 describe("Formatter Unicode offsets", () => {
   afterEach(() => { childProcess.spawn = originalSpawn; });
@@ -37,7 +40,7 @@ describe("Formatter Unicode offsets", () => {
 
   it("applies byte-offset replacements after NWN color codes without deleting code", async () => {
     const source = '// "<c ¤|>"\r\n// "<c ¥ÿ>"\r\n// "<c¡¡¡>"\r\n// "<cÔ ¶>"\r\n// "<c|  >"\r\n// "<cÿ? >"\r\n// 😀\r\nvoid testFunction() {int nFoo=1;}\r\n';
-    const document = TextDocument.create("file:///test.nss", "nwscript", 1, source);
+    const document = TextDocument.create(testUri, "nwscript", 1, source);
     const offset = source.indexOf("=1");
     mockCompiler(`<replacements><replacement offset="${Buffer.byteLength(source.slice(0, offset))}" length="1"> = </replacement></replacements>`);
     const edits = await formatter().formatDocument(document, null);
@@ -46,7 +49,7 @@ describe("Formatter Unicode offsets", () => {
 
   it("converts selection offsets and lengths to UTF-8 bytes", async () => {
     const source = '// ¥😀\nvoid main() { string s="¤😀"; }\n';
-    const document = TextDocument.create("file:///test.nss", "nwscript", 1, source);
+    const document = TextDocument.create(testUri, "nwscript", 1, source);
     const start = source.indexOf("¤");
     const end = start + "¤😀".length;
     mockCompiler("<replacements/>", (args, input) => {
@@ -59,7 +62,7 @@ describe("Formatter Unicode offsets", () => {
 
   it("preserves Unicode replacement text and measures replacement lengths in bytes", async () => {
     const source = 'void main() { string s="¥😀"; }';
-    const document = TextDocument.create("file:///test.nss", "nwscript", 1, source);
+    const document = TextDocument.create(testUri, "nwscript", 1, source);
     const offset = Buffer.byteLength(source.slice(0, source.indexOf("¥")));
     mockCompiler(`<replacements><replacement offset="${offset}" length="${Buffer.byteLength("¥😀")}">¤😀</replacement></replacements>`);
     const edits = await formatter().formatDocument(document, null);

--- a/server/test/formatter_test.ts
+++ b/server/test/formatter_test.ts
@@ -1,0 +1,68 @@
+import { describe, it, afterEach } from "mocha";
+import { expect } from "chai";
+import { EventEmitter } from "events";
+import { PassThrough } from "stream";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import ClangFormatter from "../src/Providers/Formatters/ClangFormatter";
+
+const childProcess = require("child_process");
+const originalSpawn = childProcess.spawn;
+
+describe("Formatter Unicode offsets", () => {
+  afterEach(() => { childProcess.spawn = originalSpawn; });
+
+  function mockCompiler(xml: string, inspect: (args: string[], input: string) => void = () => {}) {
+    childProcess.spawn = (_executable: string, args: string[]) => {
+      const child = new EventEmitter() as any;
+      child.stdin = new PassThrough();
+      child.stdout = new PassThrough();
+      child.stderr = new PassThrough();
+      let input = "";
+      child.stdin.on("data", (chunk: Buffer) => { input += chunk.toString(); });
+      child.stdin.on("finish", () => process.nextTick(() => {
+        inspect(args, input);
+        // Deliberately split UTF-8 sequences across process output chunks.
+        for (const byte of Buffer.from(xml)) child.stdout.write(Buffer.from([byte]));
+        child.stdout.end();
+        child.emit("close", 0);
+      }));
+      return child;
+    };
+  }
+
+  function formatter() {
+    return new ClangFormatter({ getWorkspaceRootPath: () => process.cwd() } as any,
+      true, false, [], "clang-format", {}, { info: () => {}, error: () => {} } as any);
+  }
+
+  it("applies byte-offset replacements after NWN color codes without deleting code", async () => {
+    const source = '// "<c ¤|>"\r\n// "<c ¥ÿ>"\r\n// "<c¡¡¡>"\r\n// "<cÔ ¶>"\r\n// "<c|  >"\r\n// "<cÿ? >"\r\n// 😀\r\nvoid testFunction() {int nFoo=1;}\r\n';
+    const document = TextDocument.create("file:///test.nss", "nwscript", 1, source);
+    const offset = source.indexOf("=1");
+    mockCompiler(`<replacements><replacement offset="${Buffer.byteLength(source.slice(0, offset))}" length="1"> = </replacement></replacements>`);
+    const edits = await formatter().formatDocument(document, null);
+    expect(TextDocument.applyEdits(document, edits!)).to.equal(source.replace("=1", " = 1"));
+  });
+
+  it("converts selection offsets and lengths to UTF-8 bytes", async () => {
+    const source = '// ¥😀\nvoid main() { string s="¤😀"; }\n';
+    const document = TextDocument.create("file:///test.nss", "nwscript", 1, source);
+    const start = source.indexOf("¤");
+    const end = start + "¤😀".length;
+    mockCompiler("<replacements/>", (args, input) => {
+      expect(input).to.equal(source);
+      expect(args).to.include(`-offset=${Buffer.byteLength(source.slice(0, start))}`);
+      expect(args).to.include(`-length=${Buffer.byteLength("¤😀")}`);
+    });
+    await formatter().formatDocument(document, { start: document.positionAt(start), end: document.positionAt(end) });
+  });
+
+  it("preserves Unicode replacement text and measures replacement lengths in bytes", async () => {
+    const source = 'void main() { string s="¥😀"; }';
+    const document = TextDocument.create("file:///test.nss", "nwscript", 1, source);
+    const offset = Buffer.byteLength(source.slice(0, source.indexOf("¥")));
+    mockCompiler(`<replacements><replacement offset="${offset}" length="${Buffer.byteLength("¥😀")}">¤😀</replacement></replacements>`);
+    const edits = await formatter().formatDocument(document, null);
+    expect(TextDocument.applyEdits(document, edits!)).to.equal(source.replace("¥😀", "¤😀"));
+  });
+});


### PR DESCRIPTION
Formatting source containing NWN color codes could delete or alter unrelated code because clang-format's UTF-8 byte offsets were passed directly to TextDocument's UTF-16 position API. Convert replacement offsets and selection offsets/lengths between those encodings. Preserve multibyte replacement text across stdout chunks and accumulate XML text callbacks.

Validation: all 25 tests pass, TypeScript compilation, build, and focused lint pass. Three new regression tests fail before the fix and pass afterward, covering color codes/CRLF/emoji, range formatting, and Unicode replacement text split across output chunks. The original issue reproduction was also checked with clang-format 14: applying the returned edits matches its directly formatted output exactly.

Fixes #56.
