### PR TITLE
Add issue and PR templates and disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Report incorrect behavior in the language server.
+body:
+  - type: markdown
+    attributes:
+      value: Please search existing issues first and include a small example that reproduces the problem.
+  - type: textarea
+    id: behavior
+    attributes:
+      label: What happened, and what did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Include a minimal NWScript example and any required includes. For formatting problems, show the code before and after formatting.
+      placeholder: |
+        1. Open a file containing ...
+        2. Save, format, or invoke ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: input
+    id: extension_version
+    attributes:
+      label: Extension version
+      description: Find the version in the VS Code Extensions view. For a local build, provide the commit or PR number.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include your OS and VS Code version. If using WSL, SSH, or a container, specify where the extension runs. For compiler issues, include the NWN EE version; for formatting issues, include the clang-format version.
+      placeholder: |
+        OS:
+        VS Code version:
+        Local / WSL / SSH / container:
+        NWN EE or clang-format version, if relevant:
+    validations:
+      required: true
+  - type: textarea
+    id: settings
+    attributes:
+      label: Relevant settings
+      description: Paste the relevant nwscript-ee-lsp settings. For compiler issues, include nwnInstallation and nwnHome and whether those directories exist in the extension's environment. Remove any private information.
+      render: json
+  - type: textarea
+    id: logs
+    attributes:
+      label: Language server output
+      description: Copy the relevant lines from the NWscript Language Server channel in VS Code's Output panel. For compiler or formatter issues, enable verbose in the corresponding settings and reproduce again.
+      render: text
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add screenshots, related issues, or anything else that helps explain the problem.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature request
+description: Suggest an improvement to the language server.
+body:
+  - type: markdown
+    attributes:
+      value: Please search existing issues first. Describe the user-facing behavior you would like to improve.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Describe the workflow or limitation, ideally with a small NWScript example.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Explain how you would expect the feature to work in the editor.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives or workarounds
+      description: Describe any approaches you have tried or other solutions worth considering.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add examples, screenshots, or links to related issues.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## What changes?
+
+<!-- Describe the problem and the resulting behavior. Include a before/after example when useful. -->
+
+## Related issues
+
+<!-- Link related issues. Use "Fixes #123" only when this PR fully resolves that issue. -->
+
+## Validation
+
+<!-- List tests or manual checks performed and their results. For bug fixes, explain how you reproduced the issue and verified the fix. If checks were not run, say why. -->
+
+## Compatibility
+
+<!-- Note changes to existing behavior, settings, platform support, or dependencies. Write "None" if there are no compatibility changes. -->


### PR DESCRIPTION
Add structured bug-report and feature-request forms, a pull request template, and `blank_issues_enabled: false` to guide new issues through the forms.

Bug reports require expected/actual behavior, reproduction steps, extension version, and environment details, with optional settings and logs tailored to compiler and formatter troubleshooting. The PR template prompts contributors for changes, related issues, validation, and compatibility.

Validation: parsed both forms and the chooser configuration as YAML; checked required metadata, unique field IDs, required inputs, and the disabled blank-issue setting. `git diff --check` passes. GitHub will activate the templates after this is merged into the default branch.
