### PR TITLE
Prepare experimental 2.3.0 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,11 @@ jobs:
       - name: GitHub Release
         uses: softprops/action-gh-release@v1
         with:
+          generate_release_notes: true
+          body: |
+            # Summary
+            See the [Changelog](https://github.com/PhilippeChab/nwscript-ee-language-server/blob/main/CHANGELOG.md).
+          name: ${{ github.ref_name }}
           prerelease: ${{ github.event.release.prerelease }}
           fail_on_unmatched_files: true
           files: ${{ needs.build.outputs.vsixPath }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           pat: stub
           dryRun: true
+          preRelease: ${{ github.event.release.prerelease || false }}
       - name: Upload Extension
         uses: actions/upload-artifact@v4
         with:
@@ -40,6 +41,8 @@ jobs:
   publish:
     name: Publish
     needs: build
+    permissions:
+      contents: write
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
@@ -60,11 +63,7 @@ jobs:
       - name: GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          generate_release_notes: true
-          body: |
-            # Summary
-            See the [Changelog](https://github.com/PhilippeChab/nwscript-ee-language-server/blob/main/CHANGELOG.md).
-          name: ${{ github.ref_name }}
+          prerelease: ${{ github.event.release.prerelease }}
           fail_on_unmatched_files: true
           files: ${{ needs.build.outputs.vsixPath }}
       - name: Visual Studio Marketplace Release
@@ -73,3 +72,4 @@ jobs:
           pat: ${{ secrets.VS_CODE_MARKETPLACE_TOKEN }}
           extensionFile: ${{ needs.build.outputs.vsixPath }}
           registryUrl: https://marketplace.visualstudio.com
+          preRelease: ${{ github.event.release.prerelease || false }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,3 +112,15 @@ I think we can consider the extension stable and out of beta. A big thank you to
 - Migrate diagnostics from nwnsc to the official nwn_script_comp 2.3.1 subprocess, including validation of standalone include files.
 - Clear diagnostics when a saved script becomes empty, use indexed include selections during compilation, and preserve existing compiled/debug files.
 - The official compiler reports one error at a time and has different warning coverage and language/resource restrictions; see `server/resources/compiler/README.md`.
+
+## [2.3.0] — Experimental pre-release
+
+- Use the official nwn_script_comp 2.3.1 for diagnostics, including standalone include validation.
+- Keep compiler include selection consistent with indexed documents, support deeper include chains, clear diagnostics for empty saved files, and preserve existing build artifacts.
+- Fix formatting corruption around NWN color codes and other Unicode characters, including range formatting.
+- Preserve parameter zero in signature help.
+- Validate native diagnostics on Linux, Windows, Intel macOS, and Apple Silicon.
+
+The official compiler reports one error per compilation and has different warning coverage and language/resource restrictions. Game installation and user directories must exist and may need explicit configuration, particularly when using WSL. Empty included files produce an error; adding content or a comment avoids it. See `server/resources/compiler/README.md` for details.
+
+Install using **Switch to Pre-Release Version** in VS Code's Extensions view. Stable users can remain on 2.2.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,6 @@ I think we can consider the extension stable and out of beta. A big thank you to
 - Preserve parameter zero in signature help.
 - Validate native diagnostics on Linux, Windows, Intel macOS, and Apple Silicon.
 
-The official compiler reports one error per compilation and has different warning coverage and language/resource restrictions. Game installation and user directories must exist and may need explicit configuration, particularly when using WSL. Empty included files produce an error; adding content or a comment avoids it. See `server/resources/compiler/README.md` for details.
+The official compiler reports one error per compilation and has different warning coverage and language/resource restrictions. Game installation and user directories must exist and may need explicit configuration. Empty included files produce an error; adding content or a comment avoids it. See `server/resources/compiler/README.md` for details.
 
 Install using **Switch to Pre-Release Version** in VS Code's Extensions view. Stable users can remain on 2.2.1.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/PhilippeChab/nwscript-ee-language-server"
   },
   "license": "MIT",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "author": {
     "name": "Philippe Chabot"
   },


### PR DESCRIPTION
Prepare 2.3.0 for the experimental Marketplace pre-release channel. Bump the extension version, document the compiler migration and Unicode formatting fix, and pass the GitHub release's pre-release flag through both packaging and Marketplace publishing. Keep automatic GitHub release notes, the changelog link, and the tag-based release name. Explicitly grant the publishing job permission to upload assets.

Validation: all 25 tests and TypeScript compilation pass locally. Built a 2.3.0 VSIX and verified its manifest marks it as a pre-release. Workflow YAML parses and both publishing-action inputs use the release channel flag. Cross-platform CI runs on this PR.

After merge, publish GitHub pre-release `v2.3.0` to trigger deployment. Users opt in through “Switch to Pre-Release Version”; 2.2.1 remains the stable Marketplace version.

