### PR TITLE
Bump version to 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,3 +118,8 @@ I think we can consider the extension stable and out of beta. A big thank you to
 The official compiler reports one error per compilation and has different warning coverage and language/resource restrictions. Game installation and user directories must exist and may need explicit configuration. Empty included files produce an error; adding content or a comment avoids it. See `server/resources/compiler/README.md` for details.
 
 Install using **Switch to Pre-Release Version** in VS Code's Extensions view. Stable users can remain on 2.2.1.
+
+## [2.3.1] Experimental pre-release
+
+- Update minimatch and brace-expansion dependencies to address denial-of-service vulnerabilities.
+- Remove duplicated release entries from the changelog.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/PhilippeChab/nwscript-ee-language-server"
   },
   "license": "MIT",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "Philippe Chabot"
   },


### PR DESCRIPTION
Bump the extension version from 2.3.0 to 2.3.1 for the next experimental pre-release. Add a changelog entry for the security dependency updates merged in #90 and the changelog cleanup.

Validation: package.json parses with version 2.3.1; `git diff --check` passes. The dependency updates passed all 25 tests on Linux, Windows, Intel macOS, and Apple Silicon in #90. This PR changes only the version and changelog.
