### PR TITLE
Bump version to 2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "nwscript-ee-language-server" extension will be documented in this file.
 
+## [2.3.2] Experimental pre-release
+
+- Change the language server license to GPL-3.0-only.
+- List changelog releases newest first.
+
 ## [2.3.1] Experimental pre-release
 
 - Update minimatch and brace-expansion dependencies to address denial-of-service vulnerabilities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,13 @@ All notable changes to the "nwscript-ee-language-server" extension will be docum
 ## [2.3.2] Experimental pre-release
 
 - Change the language server license to GPL-3.0-only.
-- List changelog releases newest first.
+
+Install using **Switch to Pre-Release Version** in VS Code's Extensions view.
 
 ## [2.3.1] Experimental pre-release
 
 - Update minimatch and brace-expansion dependencies to address denial-of-service vulnerabilities.
 - Remove duplicated release entries from the changelog.
-
-Install using **Switch to Pre-Release Version** in VS Code's Extensions view.
 
 ## [2.3.0] Experimental pre-release
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/PhilippeChab/nwscript-ee-language-server"
   },
   "license": "GPL-3.0-only",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "author": {
     "name": "Philippe Chabot"
   },


### PR DESCRIPTION
## What changes?

Bump the extension to 2.3.2 and add its experimental pre-release changelog entry, covering the GPL-3.0-only license. Move the pre-release installation instructions to the latest release entry.

## Related issues

None.

## Validation

- Built and packaged a pre-release VSIX locally.
- Verified the packaged version, pre-release flag, GPL license, and changelog.
- `git diff --check` passed.

## Compatibility

This release ships the GPL-3.0-only licensing change from #92. Previously released MIT versions retain their existing permissions.
